### PR TITLE
Positioning #map and search field

### DIFF
--- a/css/mapbox.css
+++ b/css/mapbox.css
@@ -38,6 +38,7 @@
 	width:30%;    
 	padding: 10px;
 	font-weight: bold;
+	z-index:999;
 }
 .map-label:hover{
 	background: #3B5998; 
@@ -45,9 +46,10 @@
 #button-container {
     background:rgb(0,0,0,0);
     position:absolute;
-    margin-top: 25px;
-    margin-left: 70%;
     z-index:1;
+    width:150px;
+	right:10px;
+	top:25px;
 }
 #button-container a{
 	position:absolute;


### PR DESCRIPTION
- removed ‘margin-left:70%’ from #button-container, it was overflowing #map. Replaced it to ‘right:10px’ because regardless the viewport size,
#button-container will always be 10px to the right.
- added ‘width:150px’ to #button-container to keep it’s normal size.
- replaced ‘margin-top:25px’ from #button-container to ‘top:25px’
- added ‘z-index:999;’ to #map, because some elements on Facebook's page was
floating on top of the #map